### PR TITLE
feat: Implement queries & mutations for Customer facet 

### DIFF
--- a/packages/customer-bookmarks-api/amplify/backend/api/CustomerBookmarksApi/resolvers/Mutation.createCustomer.req.vtl
+++ b/packages/customer-bookmarks-api/amplify/backend/api/CustomerBookmarksApi/resolvers/Mutation.createCustomer.req.vtl
@@ -1,0 +1,16 @@
+## Below example shows how to create an object from all provided GraphQL arguments
+## The primary key of the obejct is a randomly generated UUD using the $util.autoId() utility
+## Other utilities include $util.matches() for regular expressions, $util.time.nowISO8601() or
+##   $util.time.nowEpochMilliSeconds() for timestamps, and even List or Map helpers like
+##   $util.list.copyAndRetainAll() $util.map.copyAndRemoveAllKeys() for shallow copies
+## Read more: https://docs.aws.amazon.com/appsync/latest/devguide/resolver-context-reference.html#utility-helpers-in-util
+
+{
+    "version" : "2017-02-28",
+    "operation" : "PutItem",
+    "key" : {
+        "customerId": $util.dynamodb.toDynamoDBJson($context.arguments.input.customerId),
+        "sk": $util.dynamodb.toDynamoDBJson("CUST#$context.arguments.input.customerId")
+    },
+	"attributeValues" : $util.dynamodb.toMapValuesJson($ctx.args.input)
+}

--- a/packages/customer-bookmarks-api/amplify/backend/api/CustomerBookmarksApi/resolvers/Mutation.createCustomer.res.vtl
+++ b/packages/customer-bookmarks-api/amplify/backend/api/CustomerBookmarksApi/resolvers/Mutation.createCustomer.res.vtl
@@ -1,0 +1,2 @@
+## Pass back the result from DynamoDB. **
+$util.toJson($ctx.result)

--- a/packages/customer-bookmarks-api/amplify/backend/api/CustomerBookmarksApi/resolvers/Query.getCustomer.req.vtl
+++ b/packages/customer-bookmarks-api/amplify/backend/api/CustomerBookmarksApi/resolvers/Query.getCustomer.req.vtl
@@ -1,0 +1,19 @@
+## Below example shows how to look up an item with a Primary Key of "id" from GraphQL arguments
+## The helper $util.dynamodb.toDynamoDBJson automatically converts to a DynamoDB formatted request
+## There is a "context" object with arguments, identity, headers, and parent field information you can access.
+## It also has a shorthand notation avaialable:
+##  - $context or $ctx is the root object
+##  - $ctx.arguments or $ctx.args contains arguments
+##  - $ctx.identity has caller information, such as $ctx.identity.username
+##  - $ctx.request.headers contains headers, such as $context.request.headers.xyz
+##  - $ctx.source is a map of the parent field, for instance $ctx.source.xyz
+## Read more: https://docs.aws.amazon.com/appsync/latest/devguide/resolver-mapping-template-reference.html
+
+{
+    "version": "2017-02-28",
+    "operation": "GetItem",
+    "key": {
+        "customerId": $util.dynamodb.toDynamoDBJson($context.arguments.input.customerId),
+        "sk": $util.dynamodb.toDynamoDBJson("CUST#$context.arguments.input.customerId"),
+    }
+}

--- a/packages/customer-bookmarks-api/amplify/backend/api/CustomerBookmarksApi/resolvers/Query.getCustomer.res.vtl
+++ b/packages/customer-bookmarks-api/amplify/backend/api/CustomerBookmarksApi/resolvers/Query.getCustomer.res.vtl
@@ -1,0 +1,2 @@
+## Pass back the result from DynamoDB. **
+$util.toJson($ctx.result)

--- a/packages/customer-bookmarks-api/amplify/backend/api/CustomerBookmarksApi/stacks/CustomerResolvers.json
+++ b/packages/customer-bookmarks-api/amplify/backend/api/CustomerBookmarksApi/stacks/CustomerResolvers.json
@@ -1,0 +1,132 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "An auto-generated nested stack.",
+  "Metadata": {},
+  "Parameters": {
+    "AppSyncApiId": {
+      "Type": "String",
+      "Description": "The id of the AppSync API associated with this project."
+    },
+    "AppSyncApiName": {
+      "Type": "String",
+      "Description": "The name of the AppSync API",
+      "Default": "AppSyncSimpleTransform"
+    },
+    "env": {
+      "Type": "String",
+      "Description": "The environment name. e.g. Dev, Test, or Production",
+      "Default": "NONE"
+    },
+    "S3DeploymentBucket": {
+      "Type": "String",
+      "Description": "The S3 bucket containing all deployment assets for the project."
+    },
+    "S3DeploymentRootKey": {
+      "Type": "String",
+      "Description": "An S3 key relative to the S3DeploymentBucket that points to the root\nof the deployment directory."
+    }
+  },
+  "Resources": {
+    "CreateCustomerResolver": {
+      "Type": "AWS::AppSync::Resolver",
+      "Properties": {
+        "ApiId": {
+          "Ref": "AppSyncApiId"
+        },
+        "DataSourceName": "CustomerBookmarkTable",
+        "TypeName": "Mutation",
+        "FieldName": "createCustomer",
+        "RequestMappingTemplateS3Location": {
+          "Fn::Sub": [
+            "s3://${S3DeploymentBucket}/${S3DeploymentRootKey}/resolvers/Mutation.createCustomer.req.vtl",
+            {
+              "S3DeploymentBucket": {
+                "Ref": "S3DeploymentBucket"
+              },
+              "S3DeploymentRootKey": {
+                "Ref": "S3DeploymentRootKey"
+              }
+            }
+          ]
+        },
+        "ResponseMappingTemplateS3Location": {
+          "Fn::Sub": [
+            "s3://${S3DeploymentBucket}/${S3DeploymentRootKey}/resolvers/Mutation.createCustomer.res.vtl",
+            {
+              "S3DeploymentBucket": {
+                "Ref": "S3DeploymentBucket"
+              },
+              "S3DeploymentRootKey": {
+                "Ref": "S3DeploymentRootKey"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "GetCustomerResolver": {
+      "Type": "AWS::AppSync::Resolver",
+      "Properties": {
+        "ApiId": {
+          "Ref": "AppSyncApiId"
+        },
+        "DataSourceName": "CustomerBookmarkTable",
+        "TypeName": "Query",
+        "FieldName": "getCustomer",
+        "RequestMappingTemplateS3Location": {
+          "Fn::Sub": [
+            "s3://${S3DeploymentBucket}/${S3DeploymentRootKey}/resolvers/Query.getCustomer.req.vtl",
+            {
+              "S3DeploymentBucket": {
+                "Ref": "S3DeploymentBucket"
+              },
+              "S3DeploymentRootKey": {
+                "Ref": "S3DeploymentRootKey"
+              }
+            }
+          ]
+        },
+        "ResponseMappingTemplateS3Location": {
+          "Fn::Sub": [
+            "s3://${S3DeploymentBucket}/${S3DeploymentRootKey}/resolvers/Query.getCustomer.res.vtl",
+            {
+              "S3DeploymentBucket": {
+                "Ref": "S3DeploymentBucket"
+              },
+              "S3DeploymentRootKey": {
+                "Ref": "S3DeploymentRootKey"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "Conditions": {
+    "HasEnvironmentParameter": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Ref": "env"
+            },
+            "NONE"
+          ]
+        }
+      ]
+    },
+    "AlwaysFalse": {
+      "Fn::Equals": ["true", "false"]
+    }
+  },
+  "Outputs": {
+    "CreateCustomerResolverArn": {
+      "Description": "ARN for the created CreateCustomerResolver resource",
+      "Value": { "Fn::GetAtt" : [ "CreateCustomerResolver", "ResolverArn" ]}
+    },
+    "GetCustomerResolverArn": {
+      "Description": "ARN for the created GetCustomerResolver resource",
+      "Value": { "Fn::GetAtt" : [ "GetCustomerResolver", "ResolverArn" ]}
+    }
+  }
+}


### PR DESCRIPTION
## Change Summary

Resolvers for following were added on the customer facet:

- Create a customer item in Dynamo db
- Query a customer item from Dynamo Db by customerId

## Test Evidence

1. **Mutation executed - `createCustomer`**

```graphql
mutation createShirleyRodriguez {
  	createCustomer (input: {customerId:  "123", type: "SomeType", email: "shirley@example.net", fullName: "Shirley Rodriguez", userPreferences: "good"}){
    	customerId
    	email
  }
}
```

**Results**

```json
{
  "data": {
    "createCustomer": {
      "customerId": "123",
      "email": "shirley@example.net"
    }
  }
}
```

2. **Query executed - `getCustomer`**

```graphql
query queryShirleyRodriguez {
  getCustomer(input: {customerId:"123"}){
    customerId
    type
    email
    fullName
    userPreferences
  }
}
```

**Results**

```json
{
  "data": {
    "getCustomer": {
      "customerId": "123",
      "type": "SomeType",
      "email": "shirley@example.net",
      "fullName": "Shirley Rodriguez",
      "userPreferences": "good"
    }
  }
}
```


